### PR TITLE
fix: support specify alias to it, closes #82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,14 @@ jobs:
             --env grepTags=@smoke \
             --expect expects/describe-tags-spec.json
 
+      - name: Specify is an alias to it 🧪
+        run: |
+          npx cypress-expect \
+            --spec cypress/integration/specify-spec.js \
+            --config testFiles="specify-spec.js" \
+            --env grep="works 2" \
+            --expect-exactly expects/specify.json
+
   tests3:
     runs-on: ubuntu-20.04
     needs: install

--- a/cypress/integration/specify-spec.js
+++ b/cypress/integration/specify-spec.js
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+
+// specify is the same as it()
+
+specify('hello world', () => {})
+
+specify('works', () => {})
+
+specify('works 2 @tag1', { tags: '@tag1' }, () => {})
+
+specify('works 2 @tag1 @tag2', { tags: ['@tag1', '@tag2'] }, () => {})
+
+specify('works @tag2', { tags: '@tag2' }, () => {})

--- a/expects/specify.json
+++ b/expects/specify.json
@@ -1,0 +1,7 @@
+{
+  "hello world": "pending",
+  "works": "pending",
+  "works 2 @tag1": "passed",
+  "works 2 @tag1 @tag2": "passed",
+  "works @tag2": "pending"
+}

--- a/src/support.js
+++ b/src/support.js
@@ -162,8 +162,11 @@ function cypressGrep() {
     return
   }
 
-  // overwrite "context" which is an alias to describe
+  // overwrite "context" which is an alias to "describe"
   context = describe
+
+  // overwrite "specify" which is an alias to "it"
+  specify = it
 
   // keep the ".skip", ".only" methods the same as before
   it.skip = _it.skip


### PR DESCRIPTION
- closes #82
- added `specify` as an alias to `it` and tests