### PR TITLE
docs: re-organize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ $ npx cypress run --env grep="-hello world"
 $ npx cypress run --env grep="hello; -world"
 ```
 
-**Note:** An inverted name filter that matches a suite name does not exclude its tests.
+**Note:** Inverted title filter is not compativle with the `grepFilterSpecs` option
 
 ## Filter with tags
 
@@ -293,6 +293,8 @@ If you want to run all tests with tag `@slow` but without tag `@smoke`:
 --env grepTags=@slow+-@smoke
 ```
 
+**Note:** Inverted tag filter is not compativle with the `grepFilterSpecs` option
+
 ### Grep untagged tests
 
 Sometimes you want to run only the tests without any tags, and these tests are inside the describe blocks without any tags.
@@ -315,7 +317,7 @@ $ npx cypress run --env grepTags=@smoke,grepFilterSpecs=true
 
 **Note 1:** this requires installing this plugin in your project's plugin file, see the [Install](#install).
 
-**Note 2:** the `grepFilterSpecs` option is only compatible with the positive `grep` and `grepTags` options, not with the negative "!..." filter.
+**Note 2:** the `grepFilterSpecs` option is only compatible with the positive `grep` and `grepTags` options, not with the negative (inverted) "-..." filter.
 
 **Note 3:** if there are no files remaining after filtering, the plugin prints a warning and leaves all files unchanged to avoid the test runner erroring with "No specs found".
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Table of Contents
 <!-- MarkdownTOC autolink="true" -->
 
 - [Install](#install)
-  - [Plugin file](#plugin-file)
+  - [Support file](#support-file)
+  - [Config file](#config-file)
 - [Usage Overview](#usage-overview)
 - [Filter by test title](#filter-by-test-title)
   - [OR substring matching](#or-substring-matching)
@@ -38,8 +39,9 @@ Table of Contents
   - [Tags in the test config object](#tags-in-the-test-config-object)
   - [AND tags](#and-tags)
   - [OR tags](#or-tags)
-  - [Test suites](#test-suites-1)
-  - [Invert tag](#invert-tag)
+  - [Inverted tags](#inverted-tags)
+  - [NOT tags](#not-tags)
+  - [Tags in test suites](#tags-in-test-suites)
   - [Grep untagged tests](#grep-untagged-tests)
 - [Pre-filter specs \(grepFilterSpecs\)](#pre-filter-specs-grepfilterspecs)
 - [Omit filtered tests \(grepOmitFiltered\)](#omit-filtered-tests-grepomitfiltered)
@@ -56,6 +58,7 @@ Table of Contents
 - [See also](#see-also)
 - [Migration guide](#migration-guide)
   - [from v1 to v2](#from-v1-to-v2)
+  - [from v2 to v3](#from-v2-to-v3)
 - [Videos & Blog Posts](#videos--blog-posts)
 - [Blog posts](#blog-posts)
 - [Small print](#small-print)
@@ -65,7 +68,7 @@ Table of Contents
 
 ## Install
 
-Assuming you have Cypress installed, add this module as a dev dependency
+Assuming you have Cypress installed, add this module as a dev dependency.
 
 ```shell
 # using NPM
@@ -74,7 +77,10 @@ npm i -D cypress-grep
 yarn add -D cypress-grep
 ```
 
+**Note**: cypress-grep only works with Cypress version >= 10.
+
 ### Support file
+
 **required:** load this module from the [support file](https://on.cypress.io/writing-and-organizing-tests#Support-file) or at the top of the spec file if not using the support file. You improve the registration function and then call it:
 
 ```js
@@ -88,7 +94,6 @@ registerCypressGrep()
 import registerCypressGrep from 'cypress-grep'
 registerCypressGrep()
 ```
-
 
 ### Config file
 
@@ -259,7 +264,42 @@ You can run tests that match one tag or another using spaces. Make sure to quote
 --env grepTags='@slow @critical'
 ```
 
-### Test suites
+### Inverted tags
+
+You can skip running the tests with specific tag using the invert option: prefix the tag with the character `-`.
+
+```
+# do not run any tests with tag "@slow"
+--env grepTags=-@slow
+```
+
+If you want to run all tests with tag `@slow` but without tag `@smoke`:
+
+```
+--env grepTags=@slow+-@smoke
+```
+
+**Note:** Inverted tag filter is not compativle with the `grepFilterSpecs` option
+
+### NOT tags
+
+You can skip running the tests with specific tag, even if they have a tag that should run, using the not option: prefix the tag with `--`.
+
+Note this is the same as appending `+-<tag to never run>` to each tag. May be useful with large number of tags.
+
+If you want to run tests with tags `@slow` or `@regression` but without tag `@smoke`
+
+```
+--env grepTags='@slow @regression --@smoke'
+```
+
+which is equivalent to
+
+```
+--env grepTags='@slow+-@smoke @regression+-@smoke'
+```
+
+### Tags in test suites
 
 The tags are also applied to the "describe" blocks. In that case, the tests look up if any of their outer suites are enabled.
 
@@ -277,23 +317,6 @@ describe('block with config tag', { tags: '@smoke' }, () => {})
 See the [cypress/integration/describe-tags-spec.js](./cypress/integration/describe-tags-spec.js) file.
 
 **Note:** global function `describe` and `context` are aliases and both supported by this plugin.
-
-### Invert tag
-
-You can skip running the tests with specific tag using the invert option: prefix the tag with the character `-`.
-
-```
-# do not run any tests with tag "@slow"
---env grepTags=-@slow
-```
-
-If you want to run all tests with tag `@slow` but without tag `@smoke`:
-
-```
---env grepTags=@slow+-@smoke
-```
-
-**Note:** Inverted tag filter is not compativle with the `grepFilterSpecs` option
 
 ### Grep untagged tests
 
@@ -363,7 +386,7 @@ cypress run --env grep="works 2",grepOmitFiltered=true
 
 ## Disable grep
 
-If you specify the `grep` parameters inside `cypress.json` file, you can disable it from the command line
+If you specify the `grep` parameters the [config file](https://docs.cypress.io/guides/references/configuration), you can disable it from the command line
 
 ```
 $ npx cypress run --env grep=,grepTags=,burn=
@@ -561,6 +584,10 @@ The above scenario was confusing - did you want to find all tests with title con
 # enable the tests with "hello" in the title and tag "smoke"
 --env grep=hello,grepTags=smoke
 ```
+
+### from v2 to v3
+
+Version >= 3 of cypress-grep _only_ supports Cypress >= 10.
 
 ## Videos & Blog Posts
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -17,7 +17,7 @@ function cypressGrepPlugin(config) {
   const { env } = config
   if (!config.specPattern) {
     throw new Error(
-      'Incompatible versions detected, cypress-grep 2.0.0+ requires Cypress 10.0.0+ ',
+      'Incompatible versions detected, cypress-grep 3.0.0+ requires Cypress 10.0.0+ ',
     )
   }
 


### PR DESCRIPTION
Hi,

I've taken the liberty to re-organize the readme.

The goal was primarily to make it easier to find the relevant API faster, because not all options are available for name / tag filtering. There was also a bit of duplicated info.

The ToC should help with finding the info quicker, too.

The only things that have changed content-wise is marked in a PR comment.

- table of contents
- move "api" sections to the top
- separate name + tag filter docs, because not all functionality
is available for both
- group general api info together