### PR TITLE
Add support for explicit not tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,6 +419,13 @@ jobs:
             --env grepTags="@tag1 --@tag2" \
             --expect-exactly expects/explicit-spec.json
 
+      - name : explicit not tags work with omitFiltered
+        run: |
+          npx cypress-expect \
+            --config testFiles="**/explicit-spec.js" \
+            --env grepTags="@tag1 --@tag2",grepOmitFiltered=true \
+            --expect-exactly expects/explicit-omit-spec.json
+
   release:
     needs: [tests1, tests2, tests3]
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,13 @@ jobs:
             --env grepTags="@sanity+@screen-b" \
             --expect-exactly expects/inherits-tag-spec.json
 
+      - name : explicit not tags prevent test from running
+        run: |
+          npx cypress-expect \
+            --config testFiles="**/explicit-spec.js" \
+            --env grepTags="@tag1 --@tag2" \
+            --expect-exactly expects/explicit-spec.json
+
   release:
     needs: [tests1, tests2, tests3]
     runs-on: ubuntu-20.04

--- a/README.md
+++ b/README.md
@@ -361,6 +361,24 @@ You can run tests that match one tag or another using spaces. Make sure to quote
 --env grepTags='@slow @critical'
 ```
 
+### NOT tags
+
+You can skip running the tests with specific tag, even if they have a tag that should run, using the not option: prefix the tag with `--`.
+
+Note this is the same as appending `+-<tag to never run>` to each tag. May be useful with large number of tags.
+
+If you want to run tests with tags `@slow` or `@regression` but without tag `@smoke`
+
+```
+--env grepTags='@slow @regression --@smoke'
+```
+
+which is equivalent to
+
+```
+--env grepTags='@slow+-@smoke @regression+-@smoke'
+```
+
 ## Burn
 
 You can repeat (burn) the filtered tests to make sure they are flake-free

--- a/cypress/integration/explicit-spec.js
+++ b/cypress/integration/explicit-spec.js
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+
+it('tag1', {tags: '@tag1'}, () => {});
+
+it('tag2', {tags: '@tag2'}, () => {});
+
+it('tag3', {tags: '@tag3'}, () => {});
+
+it('tag1 and 2', {tags: ['@tag1','@tag2']}, () => {});
+
+it('tag1 and 3', {tags: ['@tag1', '@tag3']}, () => {})
+
+it('tag2 and 3', {tags: ['@tag2', '@tag3']}, () => {})
+
+it('all tags', {tags: ['@tag1', '@tag2', '@tag3']}, () => {});

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -153,6 +153,14 @@ describe('utils', () => {
         ],
       ])
     })
+
+    it('filters out explicit not tags', () => {
+      const parsed = parseTagsGrep('@tag1 --@tag2 -@tag3')
+      expect(parsed).to.deep.equal([
+        [{ tag: '@tag1', invert: false }, { tag: '@tag2', invert: true }],
+        [{ tag: '@tag3', invert: true }, { tag: '@tag2', invert: true }],
+      ])
+    })
   })
 
   context('parseGrep', () => {

--- a/expects/explicit-omit-spec.json
+++ b/expects/explicit-omit-spec.json
@@ -1,0 +1,4 @@
+{
+    "tag1": "passed",
+    "tag1 and 3": "passed"
+}

--- a/expects/explicit-spec.json
+++ b/expects/explicit-spec.json
@@ -1,0 +1,9 @@
+{
+    "tag1": "passed",
+    "tag2": "pending",
+    "tag3": "pending",
+    "tag1 and 2": "pending",
+    "tag1 and 3": "passed",
+    "tag2 and 3": "pending",
+    "all tags": "pending"
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,6 +43,8 @@ function parseTagsGrep(s) {
     return []
   }
 
+  const explicitNotTags = []
+
   // top level split - using space or comma, each part is OR
   const ORS = s
     .split(/[ ,]/)
@@ -50,6 +52,13 @@ function parseTagsGrep(s) {
     .filter(Boolean)
     .map((part) => {
       // now every part is an AND
+      if (part.startsWith('--')) {
+        explicitNotTags.push({
+          tag: part.slice(2),
+          invert: true,
+        })
+        return
+      }
       const parsed = part.split('+').map((tag) => {
         if (tag.startsWith('-')) {
           return {
@@ -67,7 +76,14 @@ function parseTagsGrep(s) {
       return parsed
     })
 
-  return ORS
+  // filter out undefined from explicit not tags
+  const ORS_filtered = ORS.filter(x => x !==undefined)
+  if(explicitNotTags.length > 0 ){
+    ORS_filtered.forEach((OR, index) => {
+      ORS_filtered[index] = OR.concat(explicitNotTags)
+    })
+  }
+  return ORS_filtered
 }
 
 function shouldTestRunTags(parsedGrepTags, tags = []) {


### PR DESCRIPTION
Add support for 'explicit not' tags.

Allows test suites with large numbers of tests and tags to set tags to not run even if other tags say to run the test

Raised this issue in #119 