### PR TITLE
Make explicit not tags work when not combined with other tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,12 @@ jobs:
             --env grepTags="@tag1 --@tag2",grepOmitFiltered=true \
             --expect-exactly expects/explicit-omit-spec.json
 
+      - name: explicit not tags work on their own
+        run: |
+          npx cypress-expect \
+            --env grepTags="--@tag1" \
+            --expect-exactly expects/invert-tag1.json
+
       - name: filter specs when using dynamic names 🧪
         run: |
           npx cypress-expect \

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -161,6 +161,13 @@ describe('utils', () => {
         [{ tag: '@tag3', invert: true }, { tag: '@tag2', invert: true }],
       ])
     })
+
+    it('filters out multiple explicit not tags', () => {
+      const parsed = parseTagsGrep('--@tag1 --@tag2')
+      expect(parsed).to.deep.equal([
+        [{ tag: '@tag1', invert: true }, { tag: '@tag2', invert: true }],
+      ])
+    })
   })
 
   context('parseGrep', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,6 +79,9 @@ function parseTagsGrep(s) {
   // filter out undefined from explicit not tags
   const ORS_filtered = ORS.filter((x) => x !== undefined)
   if (explicitNotTags.length > 0) {
+    if (!ORS_filtered.length) {
+      return [explicitNotTags];
+    }
     ORS_filtered.forEach((OR, index) => {
       ORS_filtered[index] = OR.concat(explicitNotTags)
     })


### PR DESCRIPTION
Allows test suites with a variable number of tags (zero or more)
to always exclude certain tags.

Addresses issue #129.