### PR TITLE
Correct error message regarding compatible version

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -17,7 +17,7 @@ function cypressGrepPlugin(config) {
   const { env } = config
   if (!config.specPattern) {
     throw new Error(
-      'Incompatible versions detected, cypress-grep 2.0.0+ requires Cypress 10.0.0+ ',
+      'Incompatible versions detected, cypress-grep 3.0.0+ requires Cypress 10.0.0+ ',
     )
   }
 


### PR DESCRIPTION
Correcting the error message when trying to use `cypress-grep` 3.x.x with `cypress` <10.x.x

Fixes https://github.com/cypress-io/cypress-grep/issues/132