### PR TITLE
Fix bug when only using inverted tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,6 +426,12 @@ jobs:
             --env grepTags="@tag1 --@tag2",grepOmitFiltered=true \
             --expect-exactly expects/explicit-omit-spec.json
 
+      - name: explicit not tags work on their own
+        run: |
+          npx cypress-expect \
+            --env grepTags="--@tag1" \
+            --expect-exactly expects/invert-tag1.json
+
       - name: filter specs when using dynamic names 🧪
         run: |
           npx cypress-expect \

--- a/cypress/integration/unit.js
+++ b/cypress/integration/unit.js
@@ -161,6 +161,13 @@ describe('utils', () => {
         [{ tag: '@tag3', invert: true }, { tag: '@tag2', invert: true }],
       ])
     })
+
+    it('allows all tags to be inverted', () => {
+      const parsed = parseTagsGrep('--@tag1,--@tag2')
+      expect(parsed).to.deep.equal([
+        [ { tag: '@tag1', invert: true }, { tag: '@tag2', invert: true } ]
+      ])
+    })
   })
 
   context('parseGrep', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -82,6 +82,9 @@ function parseTagsGrep(s) {
     ORS_filtered.forEach((OR, index) => {
       ORS_filtered[index] = OR.concat(explicitNotTags)
     })
+    if (ORS_filtered.length === 0) {
+      ORS_filtered[0] = explicitNotTags
+    }
   }
   return ORS_filtered
 }


### PR DESCRIPTION
If I configure Cypress like this:

`--env grepTags=--@exclude-me`

Then I expect tests to be filtered like this:

@tag1 
~@exclude-me~
@tag2